### PR TITLE
Fix parsing of resolverValidationOptions

### DIFF
--- a/Classes/Service/SchemaService.php
+++ b/Classes/Service/SchemaService.php
@@ -171,7 +171,10 @@ class SchemaService
             'typeDefs' => [],
             'resolvers' => [],
             'schemaDirectives' => [],
-            'resolverValidationOptions' => ['allowResolversNotInSchema' => true],
+            'resolverValidationOptions' => [
+                'allowResolversNotInSchema' => $configuration['resolverValidationOptions']['allowResolversNotInSchema'] ?? true,
+                'requireResolversForResolveType' => $configuration['resolverValidationOptions']['requireResolversForResolveType'] ?? null,
+            ],
         ];
 
         foreach ($schemaConfigurations as $schemaConfiguration) {


### PR DESCRIPTION
The resolverValidationOptions specified in Flow settings were not actually used and could only provided programmatically.