### PR TITLE
BUGFIX: replace multi-line exception message

### DIFF
--- a/Classes/Transform/FlowErrorTransform.php
+++ b/Classes/Transform/FlowErrorTransform.php
@@ -34,7 +34,7 @@ class FlowErrorTransform implements Transform
                 $message = $this->throwableStorage->logThrowable($previousError);
 
                 if (! $this->includeExceptionMessageInOutput) {
-                    $message = preg_replace('/.* - See also: (.+)\.txt$/', 'Internal error ($1)', $message);
+                    $message = preg_replace('/.* - See also: (.+)\.txt$/s', 'Internal error ($1)', $message);
                 }
 
                 return new Error(


### PR DESCRIPTION
If the exception message contains line-breaks, only the last line got replaced. The change treats the `$message` as a single line.