### PR TITLE
BUGFIX: Use correct type hint

### DIFF
--- a/Classes/Controller/GraphQLController.php
+++ b/Classes/Controller/GraphQLController.php
@@ -63,7 +63,7 @@ class GraphQLController extends ActionController
     /**
      * @Flow\SkipCsrfProtection
      *
-     * @param mixed[]|null $variables
+     * @param array|null $variables
      *
      * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      * @throws InvalidContextException

--- a/Classes/Controller/GraphQLController.php
+++ b/Classes/Controller/GraphQLController.php
@@ -68,6 +68,7 @@ class GraphQLController extends ActionController
      * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      * @throws InvalidContextException
      *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
      * @phpcsSuppress PEAR.Commenting.FunctionComment.MissingParamTag
      */
     public function queryAction(string $endpoint, string $query, ?array $variables = null, ?string $operationName = null): string


### PR DESCRIPTION
With latest Flow version a bug has been fixed which now raises an exception on property mapping. This is caused by the wrong type declaration of the `variables` parameter.

See: https://github.com/neos/flow-development-collection/pull/3424